### PR TITLE
Stop managing DynamoDB tables in our own custom resource

### DIFF
--- a/src/CustomResourceHandler.js
+++ b/src/CustomResourceHandler.js
@@ -10,6 +10,15 @@ resources = {
    KMSKeyGrant: require('./KMSKeyGrant'), // eslint-disable-line global-require
    SNSSQSSubscription: require('./SNSSQSSubscription'), // eslint-disable-line global-require
    CloudFrontOriginAccessIdentity: require('./CloudFrontOriginAccessIdentity'), // eslint-disable-line global-require
+   // This resource will be named "SimpleDynamoDBGlobalTable" only in 1.0.0-rc3 for the
+   // transition from the old DynamoDBGlobalTable resource to the newer, simpler one. See
+   // the code below that helps with this transition. In 1.0.0-rc4 and subsequent
+   // releases, the DynamoDBGlobalTable resource will be removed, this
+   // SimpleDynamoDBGlobalTable will replace it, and the transition code below will be
+   // deleted. Note that nobody should use the SimpleDynamoDBGlobalTable name directly
+   // (e.g. in a `Custom::SimpleDynamoDBGlobalTable` type resource), but should use the
+   // transition code so that the type stays stable as `Custom::DynamoDBGlobalTable`.
+   SimpleDynamoDBGlobalTable: require('./SimpleDynamoDBGlobalTable'), // eslint-disable-line global-require
    DynamoDBGlobalTable: require('./DynamoDBGlobalTable'), // eslint-disable-line global-require
    SimpleEmailServiceDomainVerification: require('./SimpleEmailServiceDomainVerification'), // eslint-disable-line global-require
    SimpleEmailServiceRuleSetActivation: require('./SimpleEmailServiceRuleSetActivation'), // eslint-disable-line global-require
@@ -28,10 +37,18 @@ module.exports = {
       console.log('custom resource event: %j', evt);
 
       if (_.has(resources, type)) {
-         // possible RequestType values: Create / Update / Delete
          Resource = resources[type];
+
+         // This is only temporary for the 1.0.0-rc3 transition.
+         console.log(`Type: "${type}"`);
+         if (type === 'DynamoDBGlobalTable' && evt.ResourceProperties && evt.ResourceProperties.IsSimpleType) {
+            console.log('Using simple version of DynamoDBGlobalTable');
+            Resource = resources.SimpleDynamoDBGlobalTable;
+         }
+
          resource = new Resource(evt);
          fn = function() {
+            // possible RequestType values: Create / Update / Delete
             return Q.promised(resource[`handle${evt.RequestType}`].bind(resource))()
                .catch(resource.sendError.bind(resource));
          };

--- a/src/SimpleDynamoDBGlobalTable.js
+++ b/src/SimpleDynamoDBGlobalTable.js
@@ -1,0 +1,77 @@
+'use strict';
+
+var _ = require('underscore'),
+    Q = require('q'),
+    AWS = require('aws-sdk'),
+    dynamo = new AWS.DynamoDB(),
+    BaseResource = require('./BaseResource');
+
+module.exports = BaseResource.extend({
+
+   normalizeResourceProperties: function(props) {
+      if (props.Regions) {
+         props.ReplicationGroup = _.map(props.Regions, function(dr) {
+            return { RegionName: dr.region };
+         });
+      }
+
+      return props;
+   },
+
+   doCreate: function(props) {
+      var params = _.pick(props, 'GlobalTableName', 'ReplicationGroup');
+
+      console.log('Creating global table: %j', params);
+
+      return Q.ninvoke(dynamo, 'createGlobalTable', params)
+         .then(function(resp) {
+            console.log('createGlobalTable response: %j', resp);
+            return { PhysicalResourceId: props.GlobalTableName, Arn: resp.GlobalTableDescription.GlobalTableArn };
+         });
+   },
+
+   doUpdate: async function(resourceID, props) {
+      return this._describeGlobalTable(props.GlobalTableName)
+         .then(function(desc) {
+            var tableName = props.GlobalTableName,
+                desiredRegions = _.pluck(props.ReplicationGroup, 'RegionName'),
+                existingRegions = _.pluck(desc.ReplicationGroup, 'RegionName'),
+                params = { GlobalTableName: tableName, ReplicaUpdates: [] };
+
+            console.log('Updating global table %s to match props %j', tableName, props);
+            console.log('The description of the current global table %s is: %j', tableName, desc);
+
+            // add missing regions:
+            _.each(_.difference(desiredRegions, existingRegions), function(region) {
+               params.ReplicaUpdates.push({ Create: { RegionName: region } });
+            });
+
+            // remove extra regions:
+            _.each(_.difference(existingRegions, desiredRegions), function(region) {
+               params.ReplicaUpdates.push({ Delete: { RegionName: region } });
+            });
+
+            if (_.isEmpty(params.ReplicaUpdates)) {
+               console.log('No update needed for global table %s', tableName);
+               return Q.when({ PhysicalResourceId: props.GlobalTableName, Arn: desc.GlobalTableArn });
+            }
+
+            console.log('Updating global table %s with params: %j', tableName, params);
+            return Q.ninvoke(dynamo, 'updateGlobalTable', params)
+               .then(_.constant({ PhysicalResourceId: props.GlobalTableName, Arn: desc.GlobalTableArn }));
+         });
+   },
+
+   doDelete: function(resourceID, props) {
+      console.log('No need to do anything to delete global table %s - just delete the tables in it', props.GlobalTableName);
+      return Q.when({ PhysicalResourceId: props.GlobalTableName });
+   },
+
+   _describeGlobalTable: function(tableName) {
+      return Q.ninvoke(dynamo, 'describeGlobalTable', { GlobalTableName: tableName })
+         .then(function(resp) {
+            return resp.GlobalTableDescription;
+         });
+   },
+
+});


### PR DESCRIPTION
The custom resource for creating a DynamoDB global table was excessively
complex. It allowed you to deploy DynamoDB tables in a single region,
and then when you used the custom resource to create the global table,
the resource would copy those tables to other regions for you before
creating the global table. This caused problems whenever new
CloudFormation support was added for new features of DynamoDB tables; it
was also needlessly complex on its own because of the complexity of
eventually-consistent descriptions of tables, etc.

Rather than continuing to manage DynamoDB tables ourselves, we instead
now recommend creating the (empty) tables in all the regions you want
them in using CloudFormation natively. Then (perhaps in a different
stack), use the custom resource to create the global table on its own.
This drastically reduces the complexity of the custom resource.

For one single RC release (1.0.0-rc3), we will leave the old custom
resource in the codebase, working exactly as it always has. If you want
to use the newer, simpler type of global table resource, add a
`IsSimpleType: true` property to your global table resource. Then, in
the following RC release (rc4), the old "complex" global table will go
away and the newer "simple" resource will remain, without the need for
the `IsSimpleType` property.