### PR TITLE
fix: return ES JSON parse error to CFN instead of invoking Lambda retry

### DIFF
--- a/src/lib/ElasticSearchClient.js
+++ b/src/lib/ElasticSearchClient.js
@@ -51,8 +51,8 @@ module.exports = Class.extend({
                   try {
                      data.body = JSON.parse(responseBody);
                   } catch(e) {
-                     console.log('Invalid JSON body:', responseBody);
-                     throw e;
+                     console.log('Invalid JSON body:', responseBody, e);
+                     deferred.reject(new Error('Request failed due to invalid JSON body. Raw Body: ' + responseBody));
                   }
                }
 


### PR DESCRIPTION
When an ES request fails due to a bad response, the custom resource should fail. Before this PR, the Lambda function would error and get reinvoked, with CFN eventually giving up on the function reporting "Custom Resource failed to stabilize in expected time".